### PR TITLE
Separate specs and implementation

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--require spec_helper

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org/'
 
-gem 'rspec-expectations'
+gem 'rspec', '~> 3.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,16 @@ GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.2.5)
+    rspec (3.4.0)
+      rspec-core (~> 3.4.0)
+      rspec-expectations (~> 3.4.0)
+      rspec-mocks (~> 3.4.0)
+    rspec-core (3.4.2)
+      rspec-support (~> 3.4.0)
     rspec-expectations (3.4.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-mocks (3.4.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.4.0)
     rspec-support (3.4.1)
@@ -11,7 +20,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  rspec-expectations
+  rspec (~> 3.4)
 
 BUNDLED WITH
    1.11.2

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ```ruby
-$ irb -rbundler/setup -I. -rnoughts_and_crosses
+$ irb -Ilib -rboard
 
->> b = board('_x_ ___ ___')
+>> b = Board('_x_ ___ ___')
 => _x_
    ___
    ___
@@ -50,7 +50,7 @@ $ irb -rbundler/setup -I. -rnoughts_and_crosses
 => true
 
 
->> b = board('___ _x_ ___')
+>> b = Board('___ _x_ ___')
 => ___
    _x_
    ___
@@ -84,7 +84,7 @@ $ irb -rbundler/setup -I. -rnoughts_and_crosses
 => 0
 
 
->> b = board('_o_ _x_ ___')
+>> b = Board('_o_ _x_ ___')
 => _o_
    _x_
    ___

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -1,6 +1,3 @@
-require 'rspec/expectations'
-include RSpec::Matchers
-
 class Board
   NOUGHT, CROSS, BLANK = 'o', 'x', '_'
 
@@ -75,90 +72,6 @@ class Board
   end
 end
 
-def board(string)
+def Board(string)
   Board.new(string.gsub(/\s/, '').chars.each_slice(3).to_a)
 end
-
-expect(board('
-             xxx
-             xoo
-             _o_')).to be_win_for('x')
-
-expect(board(<<~BOARD)).to be_win_for('x')
-  xox
-  xxo
-  oxx
-BOARD
-
-expect(board(<<~BOARD)).to be_win_for('x')
-  xox
-  oxo
-  xxo
-BOARD
-
-expect(board('
-             ooo
-             oxx
-             _x_')).to be_lose_for('x')
-
-expect(board(<<~BOARD)).to be_draw_for('x')
-  oox
-  xxo
-  oxo
-BOARD
-
-expect(board(<<~BOARD)).not_to be_draw_for('x')
-  oox
-  xxo
-  o_o
-BOARD
-
-expect(board('
-  oox
-  _xo
-  o_o
-').next_for('x')).to contain_exactly \
-board('
-  oox
-  _xo
-  oxo
-'),
-board('
-  oox
-  xxo
-  o_o
-')
-
-expect(board('
-  oo_
-  xx_
-  oxo
-             ').score_for('x')).to eq 1
-
-expect(board('
-  oo_
-  xx_
-  oxo
-             ').score_for('o')).to eq 1
-
-expect(board('
-  oo_
-  x__
-  oxo
-             ').score_for('x')).to eq -1
-
-expect(board('
-  oo_
-  x__
-  oxo
-             ').score_for('o')).to eq 1
-
-expect(board('
-  oo_
-  xx_
-  oxo
-             ').move_for('x')).to eq board('
-  oo_
-  xxx
-  oxo
-             ')

--- a/spec/.gitignore
+++ b/spec/.gitignore
@@ -1,0 +1,1 @@
+examples.txt

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -1,0 +1,123 @@
+require 'Board'
+
+RSpec.describe Board do
+  describe '#win_for?' do
+    it 'detects horizontal wins' do
+      expect(Board(<<-BOARD)).to be_win_for('x')
+        xxx
+        xoo
+        _o_
+      BOARD
+    end
+
+    it 'detects diagonal wins from top-left to bottom-right' do
+      expect(Board(<<-BOARD)).to be_win_for('x')
+        xox
+        xxo
+        oxx
+      BOARD
+    end
+
+    it 'detects diagonal wins from top-right to bottom-left' do
+      expect(Board(<<-BOARD)).to be_win_for('x')
+        xox
+        oxo
+        xxo
+      BOARD
+    end
+  end
+
+  describe '#lose_for?' do
+    it 'is true when the opponent wins' do
+      expect(Board(<<-BOARD)).to be_lose_for('x')
+        ooo
+        oxx
+        _x_
+      BOARD
+    end
+  end
+
+  describe '#draw_for?' do
+    it 'is true when neither player wins and the Board is full' do
+      expect(Board(<<-BOARD)).to be_draw_for('x')
+        oox
+        xxo
+        oxo
+      BOARD
+    end
+
+    it 'is false if the Board is not full' do
+      expect(Board(<<-BOARD)).not_to be_draw_for('x')
+        oox
+        xxo
+        o_o
+      BOARD
+    end
+  end
+
+  describe '#next_for' do
+    it 'generates all possible next moves' do
+      expect(Board(<<-BOARD).next_for('x')).to contain_exactly(Board(<<-BOARD2), Board(<<-BOARD3))
+        oox
+        _xo
+        o_o
+      BOARD
+        oox
+        _xo
+        oxo
+      BOARD2
+        oox
+        xxo
+        o_o
+      BOARD3
+    end
+  end
+
+  describe '#score_for' do
+    it 'returns 1 for a win' do
+      expect(Board(<<-BOARD).score_for('x')).to eq(1)
+        oo_
+        xx_
+        oxo
+      BOARD
+    end
+
+    it 'returns 1 for a win on the next move' do
+      expect(Board(<<-BOARD).score_for('o')).to eq(1)
+        oo_
+        xx_
+        oxo
+      BOARD
+    end
+
+    it 'returns -1 for a loss on the next move' do
+      expect(Board(<<-BOARD).score_for('x')).to eq(-1)
+        oo_
+        x__
+        oxo
+      BOARD
+    end
+
+    it 'returns 1 for a win two moves ahead' do
+      expect(Board(<<-BOARD).score_for('o')).to eq(1)
+        oo_
+        x__
+        oxo
+      BOARD
+    end
+  end
+
+  describe '#move_for' do
+    it 'chooses the best next move' do
+      expect(Board(<<-BOARD).move_for('x')).to eq Board(<<-BOARD2)
+        oo_
+        xx_
+        oxo
+      BOARD
+        oo_
+        xxx
+        oxo
+      BOARD2
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,18 @@
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+  config.filter_run :focus
+  config.run_all_when_everything_filtered = true
+  config.example_status_persistence_file_path = "spec/examples.txt"
+  config.disable_monkey_patching!
+  config.warnings = true
+  config.default_formatter = 'doc' if config.files_to_run.one?
+  config.order = :random
+  Kernel.srand config.seed
+end


### PR DESCRIPTION
This also adds a `Board()` convenience method on `Kernel` (as opposed to a testing-only `board` helper).
